### PR TITLE
fingerprint: notify client when cancelling succeeded

### DIFF
--- a/core/res/res/values/custom_config.xml
+++ b/core/res/res/values/custom_config.xml
@@ -70,4 +70,8 @@
 
     <!-- Whether device has dash charging support -->
     <bool name="config_hasDashCharger">false</bool>
+
+    <!-- Whether notify fingerprint client of successful cancelled authentication -->
+    <bool name="config_notifyClientOnFingerprintCancelSuccess">false</bool>
+
 </resources>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -67,4 +67,8 @@
 
     <!-- Whether device has dash charging support -->
     <java-symbol type="bool" name="config_hasDashCharger" />
+
+    <!-- Whether notify fingerprint client of successful cancelled authentication -->
+    <java-symbol type="bool" name="config_notifyClientOnFingerprintCancelSuccess" />
+
 </resources>

--- a/services/core/java/com/android/server/fingerprint/FingerprintService.java
+++ b/services/core/java/com/android/server/fingerprint/FingerprintService.java
@@ -1131,7 +1131,12 @@ public class FingerprintService extends SystemService implements IHwBinder.Death
                     if (client instanceof AuthenticationClient) {
                         if (client.getToken() == token) {
                             if (DEBUG) Slog.v(TAG, "stop client " + client.getOwnerString());
-                            client.stop(client.getToken() == token);
+                            final boolean notifyClient = mContext.getResources().getBoolean(
+                                    com.android.internal.R.bool.config_notifyClientOnFingerprintCancelSuccess);
+                            final int stopResult = client.stop(client.getToken() == token);
+                            if (notifyClient && (stopResult == 0)) {
+                                handleError(mHalDeviceId, FingerprintManager.FINGERPRINT_ERROR_CANCELED, 0);
+                            }
                         } else {
                             if (DEBUG) Slog.v(TAG, "can't stop client "
                                     + client.getOwnerString() + " since tokens don't match");


### PR DESCRIPTION
* Some fingerprint hardware hals might not notify userspace in time
  in some scenarios when successful authentication cancel is performed.
* This is observed for example in some devices that have power and/or home
  buttons merged with fingerprint sensor, but not limited to such cases.
* Add a opt-in configuration to enable client authentication cancel from
  fingerprint service when successful.
* This addresses originally an issue where requesting fingerprint to be
  disabled and then enabled will wait till cancelling timeout before changing
  fingerprint sensor state and start authenticating again.

Change-Id: I6a6795fbb795f0c6a4ff8ad27ac807e2f744c2d9
Signed-off-by: Carlo Savignano <carlosavignano@aospa.co>